### PR TITLE
Update MAKERphone.cpp

### DIFF
--- a/src/MAKERphone.cpp
+++ b/src/MAKERphone.cpp
@@ -4757,7 +4757,7 @@ void MAKERphone::writeFile(const char *path, const char *message)
 		;
 	Serial.printf("Writing file: %s\n", path);
 
-	File file = SD.open(path);
+	File file = SD.open(path, FILE_WRITE);
 	if (!file)
 	{
 		Serial.println("Failed to open file for writing");
@@ -4777,7 +4777,7 @@ void MAKERphone::appendFile(const char *path, const char *message)
 {
 	Serial.printf("Appending to file: %s\n", path);
 
-	File file = SD.open(path);
+	File file = SD.open(path, FILE_APPEND);
 	if (!file)
 	{
 		Serial.println("Failed to open file for appending");
@@ -4801,7 +4801,7 @@ String MAKERphone::readFile(const char *path)
 		;
 	Serial.printf("Reading file: %s\n", path);
 	String helper = "";
-	File file = SD.open(path);
+	File file = SD.open(path, FILE_READ);
 	if (!file)
 	{
 		Serial.println("Failed to open file for reading");


### PR DESCRIPTION
Fixed writeFile() and appendFile() by setting SD.open()'s mode parameter. Otherwise, calling either function will fail because SD.open() defaults to read-only mode.